### PR TITLE
Fix None Return Issue in get_prompt and Remove Debug Prints from gen_model_answer.py

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -308,6 +308,7 @@ class Conversation:
                     ret += role + config.mtbench.conv_role_message_separator + message + self.sep
                 else:
                     ret += role + config.mtbench.conv_role_only_separator
+            return ret
         elif self.sep_style == SeparatorStyle.JSLM_ALPHA:
             ret = self.system_message + self.sep
             for role, message in self.messages:

--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -111,7 +111,6 @@ def get_model_answers(
                 conv.append_message(conv.roles[0], qs)
                 conv.append_message(conv.roles[1], None)
                 prompt = conv.get_prompt()
-                print(prompt)
                 input_ids = tokenizer([prompt]).input_ids
 
                 if temperature < 1e-4:


### PR DESCRIPTION
This pull request addresses two main issues identified in the codebase related to the `conversation.py` and `gen_model_answer.py` files.

#### Changes in `conversation.py`:
* **Issue Fixed**: Previously, the get_prompt method in `conversation.py` was returning None when using custom prompt templates. This was due to the absence of a `return` statement at the end of the method, which failed to return the constructed prompt string.
* **Solution**: Added a `return ret` statement to ensure that the `get_prompt` method correctly returns the constructed prompt string when using custom templates. This change ensures that the method behaves as expected, facilitating the use of custom prompts in conversation generation.

#### Changes in `gen_model_answer.py`:
* **Improvement**: Removed unnecessary debug print statements from `gen_model_answer.py`. These print statements were initially used for debugging purposes but are no longer needed. Their removal cleans up the code and reduces clutter, making the codebase more maintainable and easier to read.

#### Testing:
The effectiveness of these changes has been validated through tests conducted on two different models:

* GPT-3.5-Turbo: [Test Run on Weights & Biases](https://wandb.ai/wandb-japan/llm-leaderboard-test/runs/ztt7z930)
* mistralai/Mistral-7B-Instruct-v0.2: [Test Run on Weights & Biases](https://wandb.ai/wandb-japan/llm-leaderboard-test/runs/g96w15v8)

These tests confirm that the fixes and improvements introduced in this pull request are functioning as intended, enhancing the usability and reliability of the codebase.

This pull request contributes to the overall quality and functionality of the project, ensuring that users can effectively utilize custom prompt templates and enjoy a cleaner codebase without unnecessary debug information.